### PR TITLE
Issue 25

### DIFF
--- a/YuGiOh TTS Deck Builder/YuGiOh TTS Deck Builder/MainPage.xaml.cs
+++ b/YuGiOh TTS Deck Builder/YuGiOh TTS Deck Builder/MainPage.xaml.cs
@@ -110,7 +110,7 @@ namespace YuGiOh_TTS_Deck_Builder
             YDKParts currentPart = YDKParts.unknown;
             for (int i = 0; i < strYDKLines.Count; i++)
             {
-                string strCurrentLine = strYDKLines[i];
+                string strCurrentLine = strYDKLines[i].Trim();
                 if (strCurrentLine == "#main")
                 {
                     // Set tracking variable to main deck.
@@ -398,6 +398,10 @@ namespace YuGiOh_TTS_Deck_Builder
                     content.Add(new ByteArrayContent(bytes), "image", "deck.jpg");
 
                     client.DefaultRequestHeaders.Add("Authorization", "Client-ID " + _imgur_client_id);
+
+                    // Disable Expect 100 Header because Imgur API chokes on it.
+                    client.DefaultRequestHeaders.ExpectContinue = false;
+
                     using (var message = await client.PostAsync("https://api.imgur.com/3/upload", content))
                     {
                         if (message.IsSuccessStatusCode)
@@ -528,7 +532,7 @@ namespace YuGiOh_TTS_Deck_Builder
             using (IRandomAccessStream stream = new InMemoryRandomAccessStream())//await file.OpenAsync(FileAccessMode.ReadWrite))
             {
                 BitmapPropertySet propertySet = new BitmapPropertySet();
-                BitmapTypedValue quality = new BitmapTypedValue(1.0, PropertyType.Single);
+                BitmapTypedValue quality = new BitmapTypedValue(0.8, PropertyType.Single);
                 propertySet.Add("ImageQuality", quality);
                 BitmapEncoder encoder = await BitmapEncoder.CreateAsync(BitmapEncoderGuid, stream, propertySet);
                 Stream pixelStream = deckBitmap.PixelBuffer.AsStream();

--- a/YuGiOh TTS Deck Builder/YuGiOh TTS Deck Builder/YuGiOh TTS Deck Builder.csproj
+++ b/YuGiOh TTS Deck Builder/YuGiOh TTS Deck Builder/YuGiOh TTS Deck Builder.csproj
@@ -187,16 +187,16 @@
       <Version>4.7.0.9</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.NETCore.UniversalWindowsPlatform">
-      <Version>6.2.9</Version>
+      <Version>6.2.14</Version>
     </PackageReference>
     <PackageReference Include="Newtonsoft.Json">
-      <Version>12.0.2</Version>
+      <Version>13.0.1</Version>
     </PackageReference>
     <PackageReference Include="System.Net.Http">
       <Version>4.3.4</Version>
     </PackageReference>
     <PackageReference Include="WriteableBitmapEx">
-      <Version>1.6.3</Version>
+      <Version>1.6.8</Version>
     </PackageReference>
   </ItemGroup>
   <PropertyGroup Condition=" '$(VisualStudioVersion)' == '' or '$(VisualStudioVersion)' &lt; '14.0' ">


### PR DESCRIPTION
Closes Issue 25. Updated project dependencies. Disabled Expect 100 Header that was sometimes causing Imgur API to choke. Also updated code to remove trailing white spaces from YGOPro deck file. Reduced image quality to comply with Imgur's 10MB file upload limit.